### PR TITLE
fix: use `path/posix.join` on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,12 +32,13 @@ jobs:
         run: yarn build packages/core
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         node-version: [18, 20]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - name: Check out
@@ -49,46 +50,14 @@ jobs:
       - name: Install
         run: yarn --no-immutable
       - name: Test Examples
-        run: |-
-          yarn test:json \
-            examples/cross-platform \
-            examples/node-classic \
-            examples/node-hybrid \
-            examples/node-next \
-            examples/wildcard
-          git diff --exit-code
-      - name: Report Coverage
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage/coverage-final.json
-          name: codecov
+        run: >-
+          yarn test:json
+          examples/cross-platform
+          examples/node-classic
+          examples/node-hybrid
+          examples/node-next
+          examples/wildcard
 
-  test-windows:
-    runs-on: windows-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [18, 20]
-
-    steps:
-      - name: Check out
-        uses: actions/checkout@v4
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Install
-        run: yarn --no-immutable
-      - name: Test Examples
-        run: |-
-          yarn test:json `
-            examples/cross-platform `
-            examples/node-classic `
-            examples/node-hybrid `
-            examples/node-next `
-            examples/wildcard
           git diff --exit-code
       - name: Report Coverage
         uses: codecov/codecov-action@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,3 +63,36 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage/coverage-final.json
           name: codecov
+
+  test-windows:
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18, 20]
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install
+        run: yarn --no-immutable
+      - name: Test Examples
+        run: |-
+          yarn test:json `
+            examples/cross-platform `
+            examples/node-classic `
+            examples/node-hybrid `
+            examples/node-next `
+            examples/wildcard
+          git diff --exit-code
+      - name: Report Coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage/coverage-final.json
+          name: codecov

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,7 +106,7 @@ const externalPlugin = ({ cwd, manifest, exports }: dumble.Data): Plugin => ({
       const outFile = exports[path][platform!] || exports[path].default
       if (!outFile) return null
       const outDir = dirname(exports[currentEntry][platform!])
-      let relpath = relative(outDir, outFile)
+      let relpath = relative(outDir, outFile).replace(/\\/g, '/')
       if (!relpath.startsWith('.')) relpath = './' + relpath
       return { path: relpath, external: true }
     })


### PR DESCRIPTION
otherwise it will generate invalid import string such as `.\index.mjs`